### PR TITLE
Add missing GITHUB_TOKEN to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - name: Generate lists
+        run: |
+          go run . -count 10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -22,8 +22,10 @@ jobs:
           go run . -count 10000 > top-10000.tsv
           head -1001 top-10000.tsv > top-1000.tsv
           head -101 top-10000.tsv > top-100.tsv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Daily update
+      - name: Weekly update
         uses: drud/action-cross-commit@13266270ee2da98f1d16425f6ce21c235a7f33dd
         with:
           source-folder: .


### PR DESCRIPTION
Pass [`GITHUB_TOKEN` secret](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret) (injected by GitHub) as an environment variable to the CI step.