### PR TITLE
Sleep in between API calls to respect ratelimit

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -23,7 +23,7 @@ jobs:
           head -1001 top-10000.tsv > top-1000.tsv
           head -101 top-10000.tsv > top-100.tsv
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Weekly update
         uses: drud/action-cross-commit@13266270ee2da98f1d16425f6ce21c235a7f33dd

--- a/main.go
+++ b/main.go
@@ -128,6 +128,15 @@ moreLoop:
 			"repocursor":  cursor,
 			"querystring": githubv4.String(queryString),
 		}
+
+		// When calling GraphQL APIs, there's a chance of hitting rate limits
+		// or in some cases secondary rate limits. The score of the query above is
+		// ~101 and here we sleep for 1 second in between the API calls to honor
+		// the rate limits.
+		if page > 1 {
+			time.Sleep(1 * time.Second)
+		}
+
 		if err := client.Query(ctx, &query, variables); err != nil {
 			return err
 		}


### PR DESCRIPTION
When calling GraphQL APIs, there's a chance of hitting rate limits [1]
or in some cases "secondary rate limits" [2]. The score of the query is
~101 and it seems sleep of 1 second in between will be enough to honor
the rate limits.

[1]: https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit
[2]: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits

Fixes #9 